### PR TITLE
Fix encoding of retrieved data when the field has binary collation. 

### DIFF
--- a/lib/mysql/charset.rb
+++ b/lib/mysql/charset.rb
@@ -181,6 +181,8 @@ class Mysql
       CHARSET_DEFAULT[csname] = cs if default
     end
 
+    BINARY_CHARSET_NUMBER = CHARSET_DEFAULT['binary'].number
+
     def self.by_number(n)
       raise ClientError, "unknown charset number: #{n}" unless NUMBER_TO_CHARSET.key? n
       NUMBER_TO_CHARSET[n]

--- a/lib/mysql/protocol.rb
+++ b/lib/mysql/protocol.rb
@@ -510,7 +510,7 @@ class Mysql
           v = self.class.net2value(data, f.type, unsigned)
           if v.is_a? Numeric or v.is_a? Mysql::Time
             v
-          elsif f.type == Field::TYPE_BIT or f.flags & Field::BINARY_FLAG != 0
+          elsif f.type == Field::TYPE_BIT or f.charsetnr == Charset::BINARY_CHARSET_NUMBER
             Charset.to_binary(v)
           else
             Charset.convert_encoding(v, charset.encoding)


### PR DESCRIPTION
I noticed that current ruby-mysql returns wrong encoding object when the field has binary collation.

Here's example:

<pre>
# coding: utf-8
require 'mysql'
conn = Mysql.new('localhost', 'root', '', 'test_db', nil, 'db/mysql/run/mysqld.sock')
conn.charset = 'utf8'
conn.query('create temporary table t (utf8 varchar(10) charset utf8, utf8_bin varchar(10) charset utf8 collate utf8_bin)')
conn.prepare('insert into t (utf8, utf8_bin) values (?, ?)').execute('あ', 'あ')

p conn.prepare('select * from t').execute.fetch
# => ["あ", "\xE3\x81\x82"]
#    expected ["あ", "あ"], but got wrong!
</pre>


I wrote a patch to fix this problem. Please merge it.
