### PR TITLE
Update packet.rb

### DIFF
--- a/lib/mysql/packet.rb
+++ b/lib/mysql/packet.rb
@@ -67,7 +67,8 @@ class Mysql
     end
 
     def eof?
-      @data[0] == ?\xfe && @data.length == 5
+      type, warnings, flags=@data.unpack("Cvv")
+      type == 0xfe && @data.length == 5
     end
 
     def to_s


### PR DESCRIPTION
eof? method can fail to recognise EOF, possibly depending on encodings. By explicitly unpacking the packet, the EOF packet first byte is always correctly recognised
