### PR TITLE
Add Support for MEDIUM_BLOB

### DIFF
--- a/lib/mysql/protocol.rb
+++ b/lib/mysql/protocol.rb
@@ -25,6 +25,8 @@ class Mysql
       case type
       when Field::TYPE_STRING, Field::TYPE_VAR_STRING, Field::TYPE_NEWDECIMAL, Field::TYPE_BLOB
         return pkt.lcs
+      when Field::TYPE_MEDIUM_BLOB
+        return pkt.lcs
       when Field::TYPE_TINY
         v = pkt.utiny
         return unsigned ? v : v < 128 ? v : v-256

--- a/lib/mysql/protocol.rb
+++ b/lib/mysql/protocol.rb
@@ -23,9 +23,7 @@ class Mysql
     # Object :: converted value.
     def self.net2value(pkt, type, unsigned)
       case type
-      when Field::TYPE_STRING, Field::TYPE_VAR_STRING, Field::TYPE_NEWDECIMAL, Field::TYPE_BLOB
-        return pkt.lcs
-      when Field::TYPE_MEDIUM_BLOB
+      when Field::TYPE_STRING, Field::TYPE_VAR_STRING, Field::TYPE_NEWDECIMAL, Field::TYPE_BLOB, Field::TYPE_MEDIUM_BLOB
         return pkt.lcs
       when Field::TYPE_TINY
         v = pkt.utiny


### PR DESCRIPTION
I've been using this code in production for a few months now.  I had a weird function in some SQL that was producing a MEDIUM_BLOB (which was not handled by the changed function).  I couldn't find an easy way to add a  spec for this change, but would be happen to resubmit with test code if you can point me to a proper spec to modify.