### PR TITLE
Updated README.rdoc to explain how to get auto-generated values.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -31,6 +31,10 @@ MySQL connector for Ruby.
  stmt = my.prepare('insert into tblname (col1,col2) values (?,?)')
  stmt.execute 123, 'abc'
 
+ res = local.prepare("insert into kk (description) values (?)")
+ res.execute 'ruby mysql test'
+ id = local.protocol.insert_id    # Auto-generated insert ID (<Fixnum>)
+
 == Incompatible with MySQL/Ruby 2.8.x
 
 * Ruby 1.8.x ではシフトJISのような安全でないマルチバイト文字セットに対して Mysql#escape_string を使用すると例外が発生します。

--- a/README.rdoc
+++ b/README.rdoc
@@ -31,9 +31,11 @@ MySQL connector for Ruby.
  stmt = my.prepare('insert into tblname (col1,col2) values (?,?)')
  stmt.execute 123, 'abc'
 
- res = local.prepare("insert into kk (description) values (?)")
- res.execute 'ruby mysql test'
- id = local.protocol.insert_id    # Auto-generated insert ID (<Fixnum>)
+
+
+ stmt = my.prepare("insert into kk (description) values (?)")
+ stmt.execute 'ruby mysql test'
+ id = stmt.protocol.insert_id    # Auto-generated insert ID (<Fixnum>)
 
 == Incompatible with MySQL/Ruby 2.8.x
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -35,7 +35,7 @@ MySQL connector for Ruby.
 
  stmt = my.prepare("insert into kk (description) values (?)")
  stmt.execute 'ruby mysql test'
- id = stmt.protocol.insert_id    # Auto-generated insert ID (<Fixnum>)
+ id = my.protocol.insert_id    # Auto-generated insert ID (<Fixnum>)
 
 == Incompatible with MySQL/Ruby 2.8.x
 


### PR DESCRIPTION
This patch documents how to retrieve auto-generated values, which is something really useful to know. Since those fields do not appear in the RDoc-generated docs, the user should dive into the code to get to know how to do that. This should be a straightforward task and therefore it should be in the documentation.