### PR TITLE
Seek to beginning of result set before iterating

### DIFF
--- a/lib/mysql.rb
+++ b/lib/mysql.rb
@@ -670,6 +670,7 @@ class Mysql
     # @yield [Array] record data
     # @return [self] self. If block is not specified, this returns Enumerator.
     def each(&block)
+      data_seek(0)
       return enum_for(:each) unless block
       while rec = fetch
         block.call rec
@@ -682,6 +683,7 @@ class Mysql
     # @yield [Hash] record data
     # @return [self] self. If block is not specified, this returns Enumerator.
     def each_hash(with_table=nil, &block)
+      data_seek(0)
       return enum_for(:each_hash, with_table) unless block
       while rec = fetch_hash(with_table)
         block.call rec
@@ -964,6 +966,7 @@ class Mysql
     # @return [Mysql::Stmt] self
     # @return [Enumerator] If block is not specified
     def each(&block)
+      data_seek(0)
       return enum_for(:each) unless block
       while rec = fetch
         block.call rec
@@ -977,6 +980,7 @@ class Mysql
     # @return [Mysql::Stmt] self
     # @return [Enumerator] If block is not specified
     def each_hash(with_table=nil, &block)
+      data_seek(0)
       return enum_for(:each_hash, with_table) unless block
       while rec = fetch_hash(with_table)
         block.call rec

--- a/test/test_mysql.rb
+++ b/test/test_mysql.rb
@@ -815,6 +815,18 @@ class TestMysql < Test::Unit::TestCase
       end
     end
 
+    test '#each_hash iterate block with a hash, after performing a count' do
+      expect = [{"id"=>"1","str"=>"abc"}, {"id"=>"2","str"=>"defg"}, {"id"=>"3","str"=>"hi"}, {"id"=>"4","str"=>nil}]
+      expect_count = expect.length
+      @res.count
+      block_count = 0
+      @res.each_hash do |a|
+        assert{ a == expect.shift }
+        block_count += 1
+      end
+      assert{ block_count == expect_count}
+    end
+
     test '#row_tell returns position of current record, #row_seek set position of current record' do
       assert{ @res.fetch_row == ['1', 'abc'] }
       pos = @res.row_tell


### PR DESCRIPTION
Hi there...

I noticed that when calling #count on a result set and then calling #each_hash (or #each), it would appear that the set was empty. This PR is my solution to that, and I'm currently using it in production.

Let me know what you think!

Thanks,

Matt
